### PR TITLE
feat(dependencies): add new cryptography libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,20 @@
     "": {
       "name": "remix-oslo-self-auth",
       "dependencies": {
+        "@node-rs/argon2": "^1.8.3",
+        "@oslojs/binary": "^0.4.0",
+        "@oslojs/crypto": "^0.6.2",
+        "@oslojs/encoding": "^0.4.1",
+        "@oslojs/otp": "^0.2.1",
+        "@oslojs/webauthn": "^0.6.4",
+        "@pilcrowjs/object-parser": "^0.0.3",
         "@remix-run/node": "^2.11.2",
         "@remix-run/react": "^2.11.2",
         "@remix-run/serve": "^2.11.2",
         "isbot": "^4.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "uqr": "^0.1.2"
       },
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -771,6 +779,34 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-E7Vgw78I93we4ZWdYCb4DGAwRROGkMIXk7/y87UmANR+J6qsWusmC3gLt0H+O0KOt5e6O38U8oJamgbudrES/w==",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
+      "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
+      "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
@@ -1272,6 +1308,251 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
+      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.1.0",
+        "@emnapi/runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@node-rs/argon2": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2/-/argon2-1.8.3.tgz",
+      "integrity": "sha512-sf/QAEI59hsMEEE2J8vO4hKrXrv4Oplte3KI2N4MhMDYpytH0drkVfErmHBfWFZxxIEK03fX1WsBNswS2nIZKg==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@node-rs/argon2-android-arm-eabi": "1.8.3",
+        "@node-rs/argon2-android-arm64": "1.8.3",
+        "@node-rs/argon2-darwin-arm64": "1.8.3",
+        "@node-rs/argon2-darwin-x64": "1.8.3",
+        "@node-rs/argon2-freebsd-x64": "1.8.3",
+        "@node-rs/argon2-linux-arm-gnueabihf": "1.8.3",
+        "@node-rs/argon2-linux-arm64-gnu": "1.8.3",
+        "@node-rs/argon2-linux-arm64-musl": "1.8.3",
+        "@node-rs/argon2-linux-x64-gnu": "1.8.3",
+        "@node-rs/argon2-linux-x64-musl": "1.8.3",
+        "@node-rs/argon2-wasm32-wasi": "1.8.3",
+        "@node-rs/argon2-win32-arm64-msvc": "1.8.3",
+        "@node-rs/argon2-win32-ia32-msvc": "1.8.3",
+        "@node-rs/argon2-win32-x64-msvc": "1.8.3"
+      }
+    },
+    "node_modules/@node-rs/argon2-android-arm-eabi": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-android-arm-eabi/-/argon2-android-arm-eabi-1.8.3.tgz",
+      "integrity": "sha512-JFZPlNM0A8Og+Tncb8UZsQrhEMlbHBXPsT3hRoKImzVmTmq28Os0ucFWow0AACp2coLHBSydXH3Dh0lZup3rWw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-android-arm64": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-android-arm64/-/argon2-android-arm64-1.8.3.tgz",
+      "integrity": "sha512-zaf8P3T92caeW2xnMA7P1QvRA4pIt/04oilYP44XlTCtMye//vwXDMeK53sl7dvYiJKnzAWDRx41k8vZvpZazg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-darwin-arm64": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-darwin-arm64/-/argon2-darwin-arm64-1.8.3.tgz",
+      "integrity": "sha512-DV/IbmLGdNXBtXb5o2UI5ba6kvqXqPAJgmMOTUCuHeBSp992GlLHdfU4rzGu0dNrxudBnunNZv+crd0YdEQSUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-darwin-x64": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-darwin-x64/-/argon2-darwin-x64-1.8.3.tgz",
+      "integrity": "sha512-YMjmBGFZhLfYjfQ2gll9A+BZu/zAMV7lWZIbKxb7ZgEofILQwuGmExjDtY3Jplido/6leCEdpmlk2oIsME00LA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-freebsd-x64": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-freebsd-x64/-/argon2-freebsd-x64-1.8.3.tgz",
+      "integrity": "sha512-Hq3Rj5Yb2RolTG/luRPnv+XiGCbi5nAK25Pc8ou/tVapwX+iktEm/NXbxc5zsMxraYVkCvfdwBjweC5O+KqCGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-arm-gnueabihf": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-arm-gnueabihf/-/argon2-linux-arm-gnueabihf-1.8.3.tgz",
+      "integrity": "sha512-x49l8RgzKoG0/V0IXa5rrEl1TcJEc936ctlYFvqcunSOyowZ6kiWtrp1qrbOR8gbaNILl11KTF52vF6+h8UlEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-arm64-gnu": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-arm64-gnu/-/argon2-linux-arm64-gnu-1.8.3.tgz",
+      "integrity": "sha512-gJesam/qA63reGkb9qJ2TjFSLBtY41zQh2oei7nfnYsmVQPuHHWItJxEa1Bm21SPW53gZex4jFJbDIgj0+PxIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-arm64-musl": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-arm64-musl/-/argon2-linux-arm64-musl-1.8.3.tgz",
+      "integrity": "sha512-7O6kQdSKzB4Tjx/EBa8zKIxnmLkQE8VdJgPm6Ksrpn+ueo0mx2xf76fIDnbbTCtm3UbB+y+FkTo2wLA7tOqIKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-x64-gnu": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-x64-gnu/-/argon2-linux-x64-gnu-1.8.3.tgz",
+      "integrity": "sha512-OBH+EFG7BGjFyldaao2H2gSCLmjtrrwf420B1L+lFn7JLW9UAjsIPFKAcWsYwPa/PwYzIge9Y7SGcpqlsSEX0w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-x64-musl": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-x64-musl/-/argon2-linux-x64-musl-1.8.3.tgz",
+      "integrity": "sha512-bDbMuyekIxZaN7NaX+gHVkOyABB8bcMEJYeRPW1vCXKHj3brJns1wiUFSxqeUXreupifNVJlQfPt1Y5B/vFXgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-wasm32-wasi": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-wasm32-wasi/-/argon2-wasm32-wasi-1.8.3.tgz",
+      "integrity": "sha512-NBf2cMCDbNKMzp13Pog8ZPmI0M9U4Ak5b95EUjkp17kdKZFds12dwW67EMnj7Zy+pRqby2QLECaWebDYfNENTg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/argon2-win32-arm64-msvc": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-win32-arm64-msvc/-/argon2-win32-arm64-msvc-1.8.3.tgz",
+      "integrity": "sha512-AHpPo7UbdW5WWjwreVpgFSY0o1RY4A7cUFaqDXZB2OqEuyrhMxBdZct9PX7PQKI18D85pLsODnR+gvVuTwJ6rQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-win32-ia32-msvc": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-win32-ia32-msvc/-/argon2-win32-ia32-msvc-1.8.3.tgz",
+      "integrity": "sha512-bqzn2rcQkEwCINefhm69ttBVVkgHJb/V03DdBKsPFtiX6H47axXKz62d1imi26zFXhOEYxhKbu3js03GobJOLw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-win32-x64-msvc": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-win32-x64-msvc/-/argon2-win32-x64-msvc-1.8.3.tgz",
+      "integrity": "sha512-ILlrRThdbp5xNR5gwYM2ic1n/vG5rJ8dQZ+YMRqksl+lnTJ/6FDe5BOyIhiPtiDwlCiCtUA+1NxpDB9KlUCAIA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1376,6 +1657,78 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/@oslojs/asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha512-cZOLRzKfv3JTxIzNTAoiN0+utB0is9cQOOp5Xq++SE8MtIXXDLFblZGFrHCdTXLGXvUZmopeB/dFZrkh5MpKqQ==",
+      "dependencies": {
+        "@oslojs/binary": "0.4.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-0.4.0.tgz",
+      "integrity": "sha512-xi1MOhP7t9TFV1nOmzG0qIdCXdFXbeMYskhfI5eakBlU8re/xO+qjdyiBO+hl+nK4z4lZWCDjlgH8BXUWQDWFw=="
+    },
+    "node_modules/@oslojs/cbor": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@oslojs/cbor/-/cbor-0.2.2.tgz",
+      "integrity": "sha512-oA+Aztf/CBFhKuxLwi27oLmaoCsL+L8MkRM+baDBel5znx4C46ENMDsJtAlfLaH1j3C33cx0votJXQ3lqsNpdQ==",
+      "dependencies": {
+        "@oslojs/binary": "0.4.0"
+      }
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-0.6.2.tgz",
+      "integrity": "sha512-2y39MOLkkCvaBdi2TrBDtk7106fayDHRLz11K1/UvtW28VgL5/TbV/tPRTmSA5dhvQQqLYDJj3zsBkjeP+aD2w==",
+      "dependencies": {
+        "@oslojs/asn1": "0.2.3",
+        "@oslojs/binary": "0.4.0"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
+      "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q=="
+    },
+    "node_modules/@oslojs/otp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/otp/-/otp-0.2.1.tgz",
+      "integrity": "sha512-7x090dFZQ4FUU9fQh2RB5udED+aCEKvwnziRRJbHQDX+h4YiPgPEpJE4nt0WZGIUG6/vs5MPljI+vidp5mOdrQ==",
+      "dependencies": {
+        "@oslojs/binary": "0.4.0",
+        "@oslojs/crypto": "0.6.2",
+        "@oslojs/encoding": "0.3.0"
+      }
+    },
+    "node_modules/@oslojs/otp/node_modules/@oslojs/encoding": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.3.0.tgz",
+      "integrity": "sha512-i374LSDXuo2l+waPlejutIkw1zOA1wWxpvaXwQgyGsr5eZwX29hH1KIKFopPTriR4DKH+7nL7c5wNx16a/6voQ=="
+    },
+    "node_modules/@oslojs/webauthn": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@oslojs/webauthn/-/webauthn-0.6.4.tgz",
+      "integrity": "sha512-jb4byFZL4xTKrV/9v2fLR24+PhYXJ8CtGaQYzvtZoPaKWCj6pEgR/l+1kuC5hkZHUr6L7zVYjNgKfxCWFbTGVw==",
+      "dependencies": {
+        "@oslojs/asn1": "0.2.3",
+        "@oslojs/binary": "0.4.0",
+        "@oslojs/cbor": "0.2.2",
+        "@oslojs/crypto": "0.6.2",
+        "@oslojs/encoding": "0.3.0"
+      }
+    },
+    "node_modules/@oslojs/webauthn/node_modules/@oslojs/encoding": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.3.0.tgz",
+      "integrity": "sha512-i374LSDXuo2l+waPlejutIkw1zOA1wWxpvaXwQgyGsr5eZwX29hH1KIKFopPTriR4DKH+7nL7c5wNx16a/6voQ=="
+    },
+    "node_modules/@pilcrowjs/object-parser": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@pilcrowjs/object-parser/-/object-parser-0.0.3.tgz",
+      "integrity": "sha512-Vy/m7jjzTFgW5BZkoBe/NCxiSOM5mjeQrLpEdd/V4KUYhr45vNFMjWszAOgDHfth26YYEZilOZ/VjdfCdcgnhw=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1857,6 +2210,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
@@ -7681,6 +8043,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "optional": true
+    },
     "node_modules/turbo-stream": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.3.0.tgz",
@@ -7937,6 +8305,11 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/uqr": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
+      "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA=="
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,20 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@node-rs/argon2": "^1.8.3",
+    "@oslojs/binary": "^0.4.0",
+    "@oslojs/crypto": "^0.6.2",
+    "@oslojs/encoding": "^0.4.1",
+    "@oslojs/otp": "^0.2.1",
+    "@oslojs/webauthn": "^0.6.4",
+    "@pilcrowjs/object-parser": "^0.0.3",
     "@remix-run/node": "^2.11.2",
     "@remix-run/react": "^2.11.2",
     "@remix-run/serve": "^2.11.2",
     "isbot": "^4.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "uqr": "^0.1.2"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",


### PR DESCRIPTION
The changes in this commit add several new dependencies to the project, including:

- `@node-rs/argon2`: A Rust-based implementation of the Argon2 password hashing algorithm.
- `@oslojs/binary`, `@oslojs/crypto`, `@oslojs/encoding`, `@oslojs/otp`, and `@oslojs/webauthn`: A set of cryptography-related libraries from the Oslo.js project.
- `@pilcrowjs/object-parser`: A library for parsing and manipulating objects.
- `uqr`: A library for generating and parsing QR codes.

These additions provide the project with a range of cryptographic and encoding capabilities, which are likely needed for various security-related features or functionality.