### PR TITLE
feat(password): add password reset functionality

### DIFF
--- a/app/.server/db.ts
+++ b/app/.server/db.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { Kyselify } from "drizzle-orm/kysely";
-import { Kysely, SqliteDialect, sql } from "kysely";
+import { Kysely, SqliteDialect } from "kysely";
+import { password_reset_session } from "./password/schema";
 import {
   email_verification_request,
   passkey_credential,
@@ -17,6 +18,7 @@ interface SQLDatabase {
   security_key_credential: Kyselify<typeof security_key_credential>;
   sessions: Kyselify<typeof sessions>;
   email_verification_request: Kyselify<typeof email_verification_request>;
+  password_reset_session: Kyselify<typeof password_reset_session>;
 }
 
 const sqlite = new Database("data/sqlite.db");

--- a/app/.server/password/password.ts
+++ b/app/.server/password/password.ts
@@ -1,0 +1,34 @@
+import { hash, verify } from "@node-rs/argon2";
+import { sha1 } from "@oslojs/crypto/sha1";
+import { encodeHexLowerCase } from "@oslojs/encoding";
+
+export async function hashPassword(password: string): Promise<string> {
+  return await hash(password, {
+    memoryCost: 19456,
+    timeCost: 2,
+    outputLen: 32,
+    parallelism: 1,
+  });
+}
+
+export async function verifyPasswordHash(hash: string, password: string): Promise<boolean> {
+  return await verify(hash, password);
+}
+
+export async function verifyPasswordStrength(password: string): Promise<boolean> {
+  if (password.length < 8) {
+    return false;
+  }
+  const hash = encodeHexLowerCase(sha1(new TextEncoder().encode(password)));
+  const hashPrefix = hash.slice(0, 5);
+  const response = await fetch(`https://api.pwnedpasswords.com/range/${hashPrefix}`);
+  const data = await response.text();
+  const items = data.split("\n");
+  for (const item of items) {
+    const hashSuffix = item.slice(0, 35).toLowerCase();
+    if (hash === hashPrefix + hashSuffix) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/app/.server/password/password_reset.ts
+++ b/app/.server/password/password_reset.ts
@@ -1,0 +1,161 @@
+import { encodeBase32 } from "@oslojs/encoding";
+import { sql } from "kysely";
+import { db } from "../db";
+import { User } from "../user/user_db";
+import { generateRandomOTP } from "./util";
+
+export async function createPasswordResetSession(userId: number, email: string): Promise<PasswordResetSession> {
+  const idBytes = new Uint8Array(20);
+  crypto.getRandomValues(idBytes);
+  const id = encodeBase32(idBytes).toLowerCase();
+
+  const session: PasswordResetSession = {
+    id,
+    userId,
+    email,
+    expiresAt: new Date(Date.now() + 1000 * 60 * 10),
+    code: generateRandomOTP(),
+    emailVerified: false,
+    twoFactorVerified: false,
+  };
+  await db.insertInto("password_reset_session").values({
+    code: session.code,
+    email: session.email,
+    expires_at: session.expiresAt,
+    user_id: session.userId,
+    id: session.id,
+  });
+
+  return session;
+}
+
+export async function validatePasswordResetSession(sessionId: string): Promise<PasswordResetSessionValidationResult> {
+  const row = await db
+    .selectFrom("password_reset_session")
+    .where("password_reset_session.id", "=", sessionId)
+    .innerJoin("users", "users.id", "password_reset_session.user_id")
+    .select([
+      "password_reset_session.id",
+      "password_reset_session.code",
+      "password_reset_session.email",
+      "password_reset_session.expires_at",
+      "password_reset_session.user_id",
+      "password_reset_session.email_verified",
+      "password_reset_session.two_factor_verified",
+      "users.id",
+      "users.email",
+      "users.username",
+      "users.email_verified",
+      sql<number>`IIF(users.totp_credential.id IS NOT NULL, 1, 0)`.as("totp_registered"),
+      sql<number>`IIF(users.passkey_credential.id IS NOT NULL, 1, 0)`.as("passkey_credential_registered"),
+      sql<number>`IIF(users.security_key_credential.id IS NOT NULL, 1, 0)`.as("security_key_credential_registered"),
+    ])
+    .leftJoin("passkey_credential", "passkey_credential.user_id", "users.id")
+    .leftJoin("totp_credential", "totp_credential.user_id", "users.id")
+    .leftJoin("security_key_credential", "security_key_credential.user_id", "users.id")
+    .executeTakeFirst();
+
+  if (row == null) {
+    return { session: null, user: null };
+  }
+  const session: PasswordResetSession = {
+    id: row.id,
+    userId: row.user_id,
+    email: row.email,
+    code: row.code,
+    expiresAt: row.expires_at,
+    emailVerified: Boolean(row.email_verified),
+    twoFactorVerified: Boolean(row.two_factor_verified),
+  };
+  const user: User = {
+    id: row.user_id,
+    email: row.email,
+    username: row.username,
+    email_verified: Boolean(row.email_verified),
+    totp_registered: Boolean(row.totp_registered),
+    passkey_credential_registered: Boolean(row.passkey_credential_registered),
+    security_key_credential_registered: Boolean(row.security_key_credential_registered),
+    registered_2fa: Boolean(row.totp_registered || row.security_key_credential_registered || row.totp_registered),
+  };
+
+  if (Date.now() >= session.expiresAt.getTime()) {
+    await db.deleteFrom("password_reset_session").where("password_reset_session.id", "=", session.id).execute();
+    return { session: null, user: null };
+  }
+  return { session, user };
+}
+
+export async function setPasswordResetSessionAsEmailVerified(sessionId: string): Promise<void> {
+  await db
+    .updateTable("password_reset_session")
+    .set({
+      email_verified: true,
+    })
+    .where("password_reset_session.id", "=", sessionId);
+}
+
+export async function setPasswordResetSessionAs2FAVerified(sessionId: string): Promise<void> {
+  await db
+    .updateTable("password_reset_session")
+    .set({
+      two_factor_verified: true,
+    })
+    .where("password_reset_session.id", "=", sessionId);
+}
+
+export async function invalidateUserPasswordResetSessions(userId: number): Promise<void> {
+  await db.deleteFrom("password_reset_session").where("password_reset_session.user_id", "=", userId).execute();
+}
+
+// TODO Migrate to Remix way
+export function validatePasswordResetSessionRequest(context: APIContext): PasswordResetSessionValidationResult {
+  const sessionId = context.cookies.get("password_reset_session")?.value ?? null;
+  if (sessionId === null) {
+    return { session: null, user: null };
+  }
+  const result = validatePasswordResetSession(sessionId);
+  if (result.session === null) {
+    deletePasswordResetSessionCookie(context);
+  }
+  return result;
+}
+
+// TODO Migrate to Remix way
+export function setPasswordResetSessionCookie(context: APIContext, session: PasswordResetSession): void {
+  context.cookies.set("password_reset_session", session.id, {
+    expires: session.expiresAt,
+    sameSite: "lax",
+    httpOnly: true,
+    path: "/",
+    secure: !import.meta.env.DEV,
+  });
+}
+
+// TODO Migrate to Remix way
+export function deletePasswordResetSessionCookie(context: APIContext): void {
+  context.cookies.set("password_reset_session", "", {
+    maxAge: 0,
+    sameSite: "lax",
+    httpOnly: true,
+    path: "/",
+    secure: !import.meta.env.DEV,
+  });
+}
+
+export function sendPasswordResetEmail(email: string, code: string): void {
+  console.log(`To ${email}: Your reset code is ${code}`);
+}
+
+export interface PasswordResetSession {
+  id: string;
+  userId: number;
+  email: string;
+  expiresAt: Date;
+  code: string;
+  emailVerified: boolean;
+  twoFactorVerified: boolean;
+}
+
+export type PasswordResetSessionValidationResult =
+  | { session: PasswordResetSession; user: User }
+  | { session: null; user: null };

--- a/app/.server/password/schema.ts
+++ b/app/.server/password/schema.ts
@@ -1,0 +1,16 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { users } from "../user/schema";
+
+export const password_reset_session = sqliteTable("password_reset_session", {
+  id: text("id").primaryKey(),
+  email: text("email").notNull(),
+  code: text("code").notNull(),
+  expires_at: integer("expires_at", { mode: "timestamp" }).notNull(),
+  two_factor_verified: integer("two_factor_verified", { mode: "boolean" }),
+  email_verified: integer("email_verified", { mode: "boolean" }),
+  user_id: integer("user_id")
+    .notNull()
+    .references(() => users.id, {
+      onDelete: "cascade",
+    }),
+});

--- a/app/.server/password/util.ts
+++ b/app/.server/password/util.ts
@@ -16,3 +16,10 @@ export function generateRandomOTP(): string {
   const code = encodeBase32(bytes);
   return code;
 }
+
+export function generateRandomRecoveryCode(): string {
+  const recoveryCodeBytes = new Uint8Array(10);
+  crypto.getRandomValues(recoveryCodeBytes);
+  const recoveryCode = encodeBase32(recoveryCodeBytes);
+  return recoveryCode;
+}


### PR DESCRIPTION
This commit adds the functionality for password reset in the application.
The changes include:

1. Implement password hashing and verification using Argon2.
2. Implement password strength verification using the Have I Been Pwned API.
3. Add a new `password_reset_session` table to the database schema.
4. Implement the `createPasswordResetSession` and `validatePasswordResetSession` functions to manage the password reset process.

These changes are necessary to provide a secure and user-friendly password reset mechanism for the application.